### PR TITLE
Fix remainingHours and remainingMinutes calculation

### DIFF
--- a/page/timer_progress/timer_progress.page.js
+++ b/page/timer_progress/timer_progress.page.js
@@ -49,8 +49,8 @@ Page({
         timerProcess = startTimer(end, timerLabel, canvas)
 
         function getRemainingTimeText(valueSeconds) {
-            const remainingHours = Math.floor(valueSeconds / 360)
-            const remainingMinutes = Math.floor(valueSeconds % 360 / 60)
+            const remainingHours = Math.floor(valueSeconds / 3600)
+            const remainingMinutes = Math.floor(valueSeconds % 3600 / 60)
             const remainingSeconds = valueSeconds % 60
             if (remainingHours > 0) {
                 return `${_00(remainingHours)}:${_00(remainingMinutes)}:${_00(remainingSeconds)}`


### PR DESCRIPTION
Fix `timer_progress.page.js` to use 3600 seconds as divisor/modulo when calculating remaining time, instead of 360.